### PR TITLE
[maintenance] Dependency upgrades 2022-03

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,5 +7,5 @@ mock
 tox
 flake8
 python-coveralls
-redislite==3.0.271
+redislite==6.0.674960
 redis>=2.10.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,21 +4,11 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py37, py39, flake8-py27, flake8-py37, flake8-39
+envlist = py37, py39, flake8-py37, flake8-39
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt
 commands = python {envbindir}/coverage run --source hbom -p -m py.test
-
-[testenv:flake8-py27]
-deps = flake8
-basepython = python2.7
-commands = flake8 \
-             --max-complexity=15 \
-             --exclude=./build,.env,.venv,.tox,dist,./test/ \
-             --ignore=F403 \
-             --max-line-length=99 \
-             {posargs}
 
 [testenv:flake8-py37]
 deps = flake8


### PR DESCRIPTION
There wasn't really much to upgrade this time around:

- Upgraded redislite to the latest version in `dev-requirements.txt`
- Removed python 2.7 from tox.ini since python2 virtual environments don't work on ARM macs