### PR TITLE
update redpipe & other dependencies; drop old python version support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ sdist: cleanmeta
 	python setup.py sdist
 
 bdist: cleanmeta
-	python2 setup.py bdist_wheel
 	python3 setup.py bdist_wheel
 
 install:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,5 +7,5 @@ mock
 tox
 flake8
 python-coveralls
-redislite==6.0.674960
-redis>=2.10.2
+redislite==6.2.912183
+redis>=4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-redpipe>=2.3.7
+redpipe>=4.0.1
 future

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     author_email='john@happybits.co',
     url='https://github.com/happybits/hbom',
     packages=['hbom'],
-    install_requires=['redpipe>=2.0.0', 'future'],
+    install_requires=['redpipe>=4.0.1', 'future'],
     tests_require=[
         'mock',
         'tox',
@@ -76,9 +76,8 @@ setup(
         'python-coveralls',
         'line_profiler',
         'python-coveralls',
-        'Cython>=0.23.4'
-        'redislite>=3.0.271',
-        'redis-py-cluster>=1.3.0'
+        'Cython>=0.23.4',
+        'redislite>=6.2.912183',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -4,21 +4,11 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py39, flake8-py37, flake8-39
+envlist = py39, flake8-39
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt
-commands = python {envbindir}/coverage run --source hbom -p -m py.test
-
-[testenv:flake8-py37]
-deps = flake8
-basepython = python3.7
-commands = flake8 \
-             --max-complexity=15 \
-             --exclude=./build,.env,.venv,.tox,dist,./test/ \
-             --ignore=F403 \
-             --max-line-length=99 \
-             {posargs}
+commands = python {envbindir}/coverage run --source hbom -m unittest discover -s test/
 
 [testenv:flake8-py39]
 deps = flake8


### PR DESCRIPTION
Follow-on to https://github.com/happybits/redpipe/pull/5; modernizing the codebase & dependencies a bit.

Asana: https://app.asana.com/0/1204628953228187/1207507191941713/f