### PR TITLE
point to explicit redpipe commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-redpipe>=4.2.0
+-e git+https://github.com/happybits/redpipe@4d7a0c72c14f13e894805e83d1d5306f5a579712#egg=redpipe  # redpipe v4.2.0
 future


### PR DESCRIPTION
Don't love this sort of explicit version tagging in a library, but `make tox` fails without it since `redpipe` 4.2.0 isn't `pip`-able.

Makes me think we should consider a) making `hbom` and our `redpipe` forks public and publishing them to pypi, or b) using AWS CodeArtifact to host a private pip-compatible repo.  But this is probably OK for now - these libraries don't change super often.